### PR TITLE
fix(deps): update jackson-databind to fix high CVE (uncontrolled resource consumption)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4</version>
+            <version>2.19.0</version>
         </dependency>
 
         <!-- JUnit for testing -->


### PR DESCRIPTION
## Security Dependency Updates

Resolves Dependabot security alerts by updating vulnerable packages.

### Packages updated
- jackson-databind: 2.13.4 → 2.19.0 (≥2.13.4.2 required; CVE: uncontrolled resource consumption)

### Notes
See the Dependabot alerts in the repository Security tab for full CVE details.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)