### PR TITLE
ci: declare least-privilege token permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,6 +18,12 @@ on:
         default: false
         type: boolean
 
+# Least privilege. `mvn deploy` to GitHub Packages needs packages:write; nothing here
+# needs write to repo contents.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`maven.yml` had no `permissions:` block, so it inherited the org default (`write`) — blanket write to repo contents. It only needs `packages: write` for `mvn deploy` to GitHub Packages.

Required before flipping the org default `default_workflow_permissions` to `read`; without this, publishing to GitHub Packages would break on the next push to `main`. This was the only workflow across all 22 active repos that would have broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)