### PR TITLE
Fix Semgrep workflow startup failure (inline instead of private reusable workflow)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,5 +1,7 @@
-# Caller: scans THIS repo using the shared reusable Semgrep workflow in databunker-devops.
-# Ruleset = Java language pack + the common security packs (see semgrep-reusable.yml).
+# Self-contained Semgrep SAST scan (Semgrep OSS engine + community rules — LGPL, no account needed).
+# Inlined rather than calling the shared reusable workflow in databunker-devops, because GitHub
+# blocks a PUBLIC repo from using a reusable workflow stored in a PRIVATE repo (org access does
+# not lift this). Keep the ruleset in sync with the other public SDK repos.
 name: semgrep
 
 on:
@@ -10,6 +12,8 @@ on:
   schedule:
     - cron: "13 7 * * 1"    # weekly full sweep (Mon 07:13 UTC) — offset from gitleaks (06:27)
 
+# Least privilege. security-events:write publishes SARIF to the Code Scanning tab (free on
+# public repos). Semgrep itself needs no write scope.
 permissions:
   contents: read
   security-events: write
@@ -17,6 +21,44 @@ permissions:
 jobs:
   sast:
     name: sast              # display + required-check name
-    uses: securitybunker/databunker-devops/.github/workflows/semgrep-reusable.yml@main
-    with:
-      config: "p/java p/secrets p/security-audit p/owasp-top-ten"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Semgrep (pinned)
+        run: pip install semgrep==1.170.0   # bump deliberately (semgrep.dev/docs/release-notes)
+
+      - name: Run Semgrep
+        env:
+          SEMGREP_SEND_METRICS: "off"   # no telemetry; community rules only
+        run: |
+          # --error: exit non-zero on any finding -> blocks merge when set as a required check.
+          # SARIF is written before the non-zero exit, so the upload steps (if: always()) run.
+          semgrep scan \
+            --config p/java \
+            --config p/secrets \
+            --config p/security-audit \
+            --config p/owasp-top-ten \
+            --error \
+            --sarif --output semgrep.sarif
+
+      - name: Upload SARIF to Code Scanning
+        if: always()   # publish findings even when the scan fails the check
+        uses: github/codeql-action/upload-sarif@bb16b9baa2ec4010b29f5c606d57d01190139edd # v4.37.1
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+      - name: Upload SARIF artifact (dated evidence, retained 180d)
+        if: always()   # keep the report for triage + audit evidence even on failure
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: semgrep-report-${{ github.sha }}
+          path: semgrep.sarif
+          retention-days: 180


### PR DESCRIPTION
PR #9 wired a caller for the reusable workflow in the **private** `databunker-devops` repo. GitHub blocks a **public** repo from using a reusable workflow stored in a private repo, so the run ended in `startup_failure` and the Actions tab showed the file path instead of the "semgrep" name.

Fix: replace the caller with a **self-contained** Semgrep scan (same rulesets, pinned actions, SARIF to Code Scanning + 180-day artifact). No cross-repo dependency.

Local scan: **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)