### PR TITLE
Bump version to 1.1.1-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Then add the dependency to your `pom.xml`:
 <dependency>
     <groupId>org.databunker</groupId>
     <artifactId>databunkerpro-java</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.databunker</groupId>
     <artifactId>databunkerpro-java</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>DatabunkerPro Java Client</name>


### PR DESCRIPTION
Opens development after the [v1.1.0 release](https://github.com/securitybunker/databunkerpro-java/releases/tag/v1.1.0).

The `Build java API` workflow deploys on every push to main, and GitHub Packages rejects republishing an already-released version — so leaving main on `1.1.0` would fail the deploy step on the next merge. This moves main to `1.1.1-SNAPSHOT`.

## Changes

- `pom.xml`: `1.1.0` → `1.1.1-SNAPSHOT`
- README: the "From Local Maven Repository" snippet follows main's version, since that section documents building from source. The GitHub Packages and JitPack snippets deliberately stay on the released `1.1.0` — that's what users should depend on.

## Verification

`mvn clean package` — 13/13 tests pass, artifacts build as `databunkerpro-java-1.1.1-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)